### PR TITLE
fix build with boost 1.87

### DIFF
--- a/src/kademlia/engine.hpp
+++ b/src/kademlia/engine.hpp
@@ -39,7 +39,7 @@
 #include <utility>
 #include <type_traits>
 #include <functional>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <kademlia/endpoint.hpp>
 #include <kademlia/error.hpp>

--- a/src/kademlia/engine.hpp
+++ b/src/kademlia/engine.hpp
@@ -88,7 +88,7 @@ public:
      *
      */
     engine
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , endpoint const& ipv4
         , endpoint const& ipv6
         , id const& new_id = id{} )
@@ -115,7 +115,7 @@ public:
      *
      */
     engine
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , endpoint const& initial_peer
         , endpoint const& ipv4
         , endpoint const& ipv6

--- a/src/kademlia/ip_endpoint.hpp
+++ b/src/kademlia/ip_endpoint.hpp
@@ -54,7 +54,7 @@ to_ip_endpoint( std::string const& ip
               , std::uint16_t port )
 {
     return ip_endpoint
-        { boost::asio::ip::address::from_string( ip )
+        { boost::asio::ip::make_address( ip )
         , port };
 }
 

--- a/src/kademlia/message_socket.hpp
+++ b/src/kademlia/message_socket.hpp
@@ -32,7 +32,7 @@
 
 #include <vector>
 #include <algorithm>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/asio/buffer.hpp>
 

--- a/src/kademlia/message_socket.hpp
+++ b/src/kademlia/message_socket.hpp
@@ -68,7 +68,7 @@ public:
     template< typename EndpointType >
     static resolved_endpoints
     resolve_endpoint
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , EndpointType const& e );
 
     /**
@@ -77,7 +77,7 @@ public:
     template< typename EndpointType >
     static message_socket
     ipv4
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , EndpointType const& e );
 
     /**
@@ -86,7 +86,7 @@ public:
     template< typename EndpointType >
     static message_socket
     ipv6
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , EndpointType const& e );
 
     /**
@@ -153,7 +153,7 @@ private:
      *
      */
     message_socket
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , endpoint_type const& e );
 
     /**
@@ -161,7 +161,7 @@ private:
      */
     static underlying_socket_type
     create_underlying_socket
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , endpoint_type const& e );
 
     /**
@@ -191,7 +191,7 @@ template< typename UnderlyingSocketType >
 template< typename EndpointType >
 inline message_socket< UnderlyingSocketType >
 message_socket< UnderlyingSocketType >::ipv4
-    ( boost::asio::io_service & io_service
+    ( boost::asio::io_context & io_service
     , EndpointType const& ipv4_endpoint )
 {
     auto endpoints = resolve_endpoint( io_service, ipv4_endpoint );
@@ -209,7 +209,7 @@ template< typename UnderlyingSocketType >
 template< typename EndpointType >
 inline message_socket< UnderlyingSocketType >
 message_socket< UnderlyingSocketType >::ipv6
-    ( boost::asio::io_service & io_service
+    ( boost::asio::io_context & io_service
     , EndpointType const& ipv6_endpoint )
 {
     auto endpoints = resolve_endpoint( io_service, ipv6_endpoint );
@@ -226,7 +226,7 @@ message_socket< UnderlyingSocketType >::ipv6
 template< typename UnderlyingSocketType >
 inline
 message_socket< UnderlyingSocketType >::message_socket
-    ( boost::asio::io_service & io_service
+    ( boost::asio::io_context & io_service
     , endpoint_type const& e )
     : reception_buffer_( INPUT_BUFFER_SIZE )
     , current_message_sender_()
@@ -316,7 +316,7 @@ message_socket< UnderlyingSocketType >::local_endpoint
 template< typename UnderlyingSocketType >
 inline typename message_socket< UnderlyingSocketType >::underlying_socket_type
 message_socket< UnderlyingSocketType >::create_underlying_socket
-    ( boost::asio::io_service & io_service
+    ( boost::asio::io_context & io_service
     , endpoint_type const& endpoint )
 {
     auto const e = convert_endpoint( endpoint );
@@ -335,7 +335,7 @@ template< typename UnderlyingSocketType >
 template< typename EndpointType >
 inline typename message_socket< UnderlyingSocketType >::resolved_endpoints
 message_socket< UnderlyingSocketType >::resolve_endpoint
-    ( boost::asio::io_service & io_service
+    ( boost::asio::io_context & io_service
     , EndpointType const& e )
 {
     using protocol_type = typename underlying_socket_type::protocol_type;

--- a/src/kademlia/message_socket.hpp
+++ b/src/kademlia/message_socket.hpp
@@ -342,13 +342,13 @@ message_socket< UnderlyingSocketType >::resolve_endpoint
 
     typename protocol_type::resolver r{ io_service };
     // Resolve addresses even if not reachable.
-    typename protocol_type::resolver::query::flags const f{};
-    typename protocol_type::resolver::query q{ e.address(), e.service(), f };
+    typename protocol_type::resolver::flags const f{};
     // One raw endpoint (e.g. localhost) can be resolved to
     // multiple endpoints (e.g. IPv4 / IPv6 address).
     resolved_endpoints endpoints;
 
-    for ( auto i : r.resolve( q ) )
+    auto resolver_results = r.resolve( e.address(), e.service(), f );
+    for ( auto i : resolver_results )
         // Convert from underlying_endpoint_type to endpoint_type.
         endpoints.push_back( convert_endpoint( i ) );
 

--- a/src/kademlia/network.hpp
+++ b/src/kademlia/network.hpp
@@ -67,7 +67,7 @@ public:
      *
      */
     network
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , message_socket_type && socket_ipv4
         , message_socket_type && socket_ipv6
         , on_message_received_type on_message_received )
@@ -168,7 +168,7 @@ private:
 
 private:
     ///
-    boost::asio::io_service & io_service_;
+    boost::asio::io_context & io_service_;
     ///
     message_socket_type socket_ipv4_;
     ///

--- a/src/kademlia/network.hpp
+++ b/src/kademlia/network.hpp
@@ -31,7 +31,7 @@
 #endif
 
 #include <functional>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "log.hpp"
 #include "ip_endpoint.hpp"

--- a/src/kademlia/response_router.hpp
+++ b/src/kademlia/response_router.hpp
@@ -54,7 +54,7 @@ public:
      */
     explicit
     response_router
-        ( boost::asio::io_service & io_service )
+        ( boost::asio::io_context & io_service )
             : response_callbacks_()
             , timer_( io_service )
     { }

--- a/src/kademlia/session_impl.hpp
+++ b/src/kademlia/session_impl.hpp
@@ -36,6 +36,7 @@
 #include <utility>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/udp.hpp>
+#include <boost/asio/post.hpp>
 
 #include "message_socket.hpp"
 #include "engine.hpp"

--- a/src/kademlia/session_impl.hpp
+++ b/src/kademlia/session_impl.hpp
@@ -156,7 +156,7 @@ public:
 
 private:
     ///
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     ///
     engine_type engine_;
     ///

--- a/src/kademlia/session_impl.hpp
+++ b/src/kademlia/session_impl.hpp
@@ -151,7 +151,7 @@ public:
         auto service_stopper = [ this ] ( void )
         { is_abort_requested_ = true; };
 
-        io_service_.post( service_stopper );
+        boost::asio::post( io_service_, service_stopper );
     }
 
 private:

--- a/src/kademlia/session_impl.hpp
+++ b/src/kademlia/session_impl.hpp
@@ -34,7 +34,7 @@
 #include "session_impl.hpp"
 
 #include <utility>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/udp.hpp>
 
 #include "message_socket.hpp"

--- a/src/kademlia/timer.cpp
+++ b/src/kademlia/timer.cpp
@@ -35,7 +35,7 @@ namespace kademlia {
 namespace detail {
 
 timer::timer
-    ( boost::asio::io_service & io_service )
+    ( boost::asio::io_context & io_service )
     : timer_{ io_service }
     , timeouts_{}
 {}

--- a/src/kademlia/timer.hpp
+++ b/src/kademlia/timer.hpp
@@ -33,7 +33,7 @@
 #include <map>
 #include <chrono>
 #include <functional>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/basic_waitable_timer.hpp>
 
 namespace kademlia {

--- a/src/kademlia/timer.hpp
+++ b/src/kademlia/timer.hpp
@@ -55,7 +55,7 @@ public:
      */
     explicit
     timer
-        ( boost::asio::io_service & io_service );
+        ( boost::asio::io_context & io_service );
 
     /**
      *

--- a/src/kademlia/tracker.hpp
+++ b/src/kademlia/tracker.hpp
@@ -63,7 +63,7 @@ public:
      *
      */
     tracker
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , id const& my_id
         , network_type & network
         , random_engine_type & random_engine )

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -271,8 +271,8 @@ public:
     get_first_ipv4
         ( void )
     {
-        using boost::asio::ip::address_v4;
-        return address_v4::from_string( "10.0.0.0" );
+        using boost::asio::ip::make_address_v4;
+        return make_address_v4( "10.0.0.0" );
     }
 
     /**

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -416,7 +416,7 @@ private:
         ( boost::asio::const_buffer const& buffer
         , endpoint_type const & to )
     {
-        auto i = boost::asio::buffer_cast< uint8_t const * >( buffer );
+        auto i = static_cast< uint8_t const * >( buffer.data() );
         auto e = i + boost::asio::buffer_size( buffer );
 
         packet p{ local_endpoint_, to, { i, e } }; 
@@ -518,8 +518,8 @@ private:
         assert( source_size <= boost::asio::buffer_size( to )
               && "can't store message into target buffer" );
 
-        auto source_data = boost::asio::buffer_cast< uint8_t const * >( from );
-        auto target_data = boost::asio::buffer_cast< uint8_t * >( to );
+        auto source_data = static_cast< uint8_t const * >( from.data() );
+        auto target_data = static_cast< uint8_t * >( to.data() );
 
         std::memcpy( target_data, source_data, source_size );
 

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -557,7 +557,7 @@ private:
             target->pending_reads_.pop_front();
         };
 
-        io_service_.post( perform_write );
+        boost::asio::post( io_service_, perform_write );
     }
 
     /**
@@ -592,7 +592,7 @@ private:
             pending_writes_.pop_front();
         };
 
-        io_service_.post( perform_read );
+        boost::asio::post( io_service_, perform_read );
     }
 
 private:

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -294,8 +294,8 @@ public:
     get_first_ipv6
         ( void )
     {
-        using boost::asio::ip::address_v6;
-        return address_v6::from_string( "fc00::" );
+        using boost::asio::ip::make_address_v6;
+        return make_address_v6( "fc00::" );
     }
 
     /**

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -79,7 +79,7 @@ public:
      *
      */
     fake_socket
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , protocol_type const& )
             : io_service_( io_service )
             , local_endpoint_()
@@ -597,7 +597,7 @@ private:
 
 private:
     ///
-    boost::asio::io_service & io_service_;
+    boost::asio::io_context & io_service_;
     ///
     endpoint_type local_endpoint_;
     ///

--- a/test/fake_socket.hpp
+++ b/test/fake_socket.hpp
@@ -39,6 +39,7 @@
 
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/udp.hpp>
+#include <boost/asio/post.hpp>
 
 #include <kademlia/error.hpp>
 

--- a/test/test_engine.hpp
+++ b/test/test_engine.hpp
@@ -42,7 +42,7 @@ class test_engine final
 {
 public:
     test_engine
-        ( boost::asio::io_service & service
+        ( boost::asio::io_context & service
         , endpoint const & ipv4
         , endpoint const & ipv6
         , detail::id const& new_id )
@@ -56,7 +56,7 @@ public:
     { }
 
     test_engine
-        ( boost::asio::io_service & service
+        ( boost::asio::io_context & service
         , endpoint const & initial_peer
         , endpoint const & ipv4
         , endpoint const & ipv6
@@ -122,7 +122,7 @@ private:
     using impl = detail::engine< fake_socket >;
 
 private:
-    boost::asio::io_service::work work_;
+    boost::asio::io_context::work work_;
     impl engine_;
     fake_socket::endpoint_type listen_ipv4_;
     fake_socket::endpoint_type listen_ipv6_;

--- a/test/test_engine.hpp
+++ b/test/test_engine.hpp
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <kademlia/endpoint.hpp>
 

--- a/test/test_engine.hpp
+++ b/test/test_engine.hpp
@@ -46,7 +46,7 @@ public:
         , endpoint const & ipv4
         , endpoint const & ipv6
         , detail::id const& new_id )
-            : work_( service )
+            : work_(boost::asio::make_work_guard(service))
             , engine_( service
                      , ipv4, ipv6, new_id )
             , listen_ipv4_( fake_socket::get_last_allocated_ipv4()
@@ -61,7 +61,7 @@ public:
         , endpoint const & ipv4
         , endpoint const & ipv6
         , detail::id const& new_id )
-            : work_( service )
+            : work_( service.get_executor() )
             , engine_( service
                      , initial_peer
                      , ipv4, ipv6
@@ -122,7 +122,7 @@ private:
     using impl = detail::engine< fake_socket >;
 
 private:
-    boost::asio::io_context::work work_;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
     impl engine_;
     fake_socket::endpoint_type listen_ipv4_;
     fake_socket::endpoint_type listen_ipv6_;

--- a/test/unit_tests/network_utils.cpp
+++ b/test/unit_tests/network_utils.cpp
@@ -52,7 +52,7 @@ get_temporary_listening_port
         boost::asio::ip::udp::endpoint const e
                 { boost::asio::ip::udp::v4() , port };
 
-        boost::asio::io_service io_service;
+        boost::asio::io_context io_service;
         // Try to open a socket at this address.
         boost::asio::ip::udp::socket socket{ io_service, e.protocol() };
         socket.bind( e, failure );

--- a/test/unit_tests/network_utils.hpp
+++ b/test/unit_tests/network_utils.hpp
@@ -27,7 +27,7 @@
 #define KADEMLIA_TEST_HELPERS_NETWORK_HPP
 
 #include <cstdint>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/system/system_error.hpp>

--- a/test/unit_tests/network_utils.hpp
+++ b/test/unit_tests/network_utils.hpp
@@ -44,7 +44,7 @@ create_socket
     , std::uint16_t port )
 {
     auto const a = boost::asio::ip::make_address( ip );
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     // Try to create a socket.
     typename Socket::endpoint_type endpoint( a, port );

--- a/test/unit_tests/network_utils.hpp
+++ b/test/unit_tests/network_utils.hpp
@@ -43,7 +43,7 @@ create_socket
     ( std::string const& ip
     , std::uint16_t port )
 {
-    auto const a = boost::asio::ip::address::from_string( ip );
+    auto const a = boost::asio::ip::make_address( ip );
     boost::asio::io_service io_service;
 
     // Try to create a socket.

--- a/test/unit_tests/peer_factory.hpp
+++ b/test/unit_tests/peer_factory.hpp
@@ -39,7 +39,7 @@ create_endpoint
 {
     using endpoint_type = kademlia::detail::ip_endpoint;
 
-    return endpoint_type{ boost::asio::ip::address::from_string( ip )
+    return endpoint_type{ boost::asio::ip::make_address( ip )
                         , service };
 }
 

--- a/test/unit_tests/socket_mock.hpp
+++ b/test/unit_tests/socket_mock.hpp
@@ -61,7 +61,7 @@ public:
      *
      */
     socket_mock
-        ( boost::asio::io_service & io_service
+        ( boost::asio::io_context & io_service
         , protocol_type const& )
     { }
 

--- a/test/unit_tests/task_fixture.hpp
+++ b/test/unit_tests/task_fixture.hpp
@@ -29,7 +29,7 @@
 #include <cstdint>
 #include <system_error>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "peer.hpp"
 #include "common.hpp"

--- a/test/unit_tests/task_fixture.hpp
+++ b/test/unit_tests/task_fixture.hpp
@@ -70,8 +70,8 @@ struct task_fixture
         return p;
     }
 
-    boost::asio::io_service io_service_;
-    boost::asio::io_service::work io_service_work_;
+    boost::asio::io_context io_service_;
+    boost::asio::io_context::work io_service_work_;
     tracker_mock tracker_;
     std::error_code failure_;
     routing_table_mock routing_table_;

--- a/test/unit_tests/task_fixture.hpp
+++ b/test/unit_tests/task_fixture.hpp
@@ -44,7 +44,7 @@ struct task_fixture
     task_fixture
         ( void )
         : io_service_()
-        , io_service_work_( io_service_ )
+        , io_service_work_(boost::asio::make_work_guard(io_service_))
         , tracker_( io_service_ )
         , failure_()
         , routing_table_()
@@ -71,7 +71,7 @@ struct task_fixture
     }
 
     boost::asio::io_context io_service_;
-    boost::asio::io_context::work io_service_work_;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_service_work_;
     tracker_mock tracker_;
     std::error_code failure_;
     routing_table_mock routing_table_;

--- a/test/unit_tests/test_engine.cpp
+++ b/test/unit_tests/test_engine.cpp
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "test_engine.hpp"
 

--- a/test/unit_tests/test_engine.cpp
+++ b/test/unit_tests/test_engine.cpp
@@ -39,7 +39,7 @@ namespace t = k::test;
 
 template<typename ... InitialPeer >
 std::unique_ptr< t::test_engine >
-create_test_engine( boost::asio::io_service & io_service
+create_test_engine( boost::asio::io_context & io_service
                   , d::id const& id
                   , InitialPeer &&... initial_peer )
 {
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_SUITE( test_usage )
 
 BOOST_AUTO_TEST_CASE( isolated_engine_cannot_be_constructed )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint initial_peer{ "172.18.1.2", 27980 };
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( isolated_engine_cannot_be_constructed )
 
 BOOST_AUTO_TEST_CASE( two_engines_can_find_themselves )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     d::id const id1{ "8000000000000000000000000000000000000000" };
     auto e1 = create_test_engine( io_service, id1 );
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE( two_engines_can_find_themselves )
 
 BOOST_AUTO_TEST_CASE( two_engines_can_save_and_load )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     d::id const id1{ "8000000000000000000000000000000000000000" };
     auto e1 = create_test_engine( io_service, id1 );

--- a/test/unit_tests/test_fake_socket.cpp
+++ b/test/unit_tests/test_fake_socket.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE( invokes_send_callback_when_host_is_unreachable )
 BOOST_AUTO_TEST_CASE( can_send_and_receive_messages )
 {
     a::io_context io_service;
-    a::io_context::work work(io_service);
+    auto work_guard = a::make_work_guard(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( can_detect_invalid_address )
 BOOST_AUTO_TEST_CASE( can_detect_closed_socket )
 {
     a::io_context io_service;
-    a::io_context::work work(io_service);
+    auto work_guard = a::make_work_guard(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE( can_detect_closed_socket )
 BOOST_AUTO_TEST_CASE( can_send_and_receive_messages_to_self )
 {
     a::io_context io_service;
-    a::io_context::work work(io_service);
+    auto work_guard = a::make_work_guard(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 

--- a/test/unit_tests/test_fake_socket.cpp
+++ b/test/unit_tests/test_fake_socket.cpp
@@ -27,7 +27,7 @@
 
 #include <numeric>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "buffer.hpp"
 #include "fake_socket.hpp"

--- a/test/unit_tests/test_fake_socket.cpp
+++ b/test/unit_tests/test_fake_socket.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_SUITE( test_construction )
 
 BOOST_AUTO_TEST_CASE( can_be_created )
 {
-    a::io_service io_service;
+    a::io_context io_service;
     k::test::fake_socket s( io_service
                            , a::ip::udp::endpoint().protocol() );
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE( can_be_created )
 
 BOOST_AUTO_TEST_CASE( does_not_invoke_receive_callback_until_data_is_received )
 {
-    a::io_service io_service;
+    a::io_context io_service;
     boost::asio::ip::udp::endpoint endpoint;
     k::test::fake_socket s( io_service, endpoint.protocol() );
 
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE( does_not_invoke_receive_callback_until_data_is_received )
 
 BOOST_AUTO_TEST_CASE( invokes_send_callback_when_host_is_unreachable )
 {
-    a::io_service io_service;
+    a::io_context io_service;
     boost::asio::ip::udp::endpoint endpoint;
     k::test::fake_socket s( io_service, endpoint.protocol() );
 
@@ -100,8 +100,8 @@ BOOST_AUTO_TEST_CASE( invokes_send_callback_when_host_is_unreachable )
 
 BOOST_AUTO_TEST_CASE( can_send_and_receive_messages )
 {
-    a::io_service io_service;
-    a::io_service::work work(io_service);
+    a::io_context io_service;
+    a::io_context::work work(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE( can_send_and_receive_messages )
 
 BOOST_AUTO_TEST_CASE( can_detect_invalid_address )
 {
-    a::io_service io_service;
+    a::io_context io_service;
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 
@@ -185,8 +185,8 @@ BOOST_AUTO_TEST_CASE( can_detect_invalid_address )
 
 BOOST_AUTO_TEST_CASE( can_detect_closed_socket )
 {
-    a::io_service io_service;
-    a::io_service::work work(io_service);
+    a::io_context io_service;
+    a::io_context::work work(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 
@@ -232,8 +232,8 @@ BOOST_AUTO_TEST_CASE( can_detect_closed_socket )
 
 BOOST_AUTO_TEST_CASE( can_send_and_receive_messages_to_self )
 {
-    a::io_service io_service;
-    a::io_service::work work(io_service);
+    a::io_context io_service;
+    a::io_context::work work(io_service);
     boost::asio::ip::udp::endpoint endpoint;
     endpoint.port( k::test::fake_socket::FIXED_PORT );
 

--- a/test/unit_tests/test_message.cpp
+++ b/test/unit_tests/test_message.cpp
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE( can_serialize_find_peer_response_body )
 
         kd::peer new_peer =
             { kd::id{ random_engine }
-            , { boost::asio::ip::address::from_string( IPS[ i % 2 ] )
+            , { boost::asio::ip::make_address( IPS[ i % 2 ] )
               , std::uint16_t( 1024 + i ) } };
 
         body_out.peers_.push_back( std::move( new_peer ) );
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE( can_detect_corrupted_find_peer_response_body )
 
         kd::peer new_peer =
             { kd::id{ random_engine }
-            , { boost::asio::ip::address::from_string( IPS[ i % 2 ] )
+            , { boost::asio::ip::make_address( IPS[ i % 2 ] )
               , std::uint16_t( 1024 + i ) } };
 
         body_out.peers_.push_back( std::move( new_peer ) );

--- a/test/unit_tests/test_message_socket.cpp
+++ b/test/unit_tests/test_message_socket.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_SUITE( test_construction )
 
 BOOST_AUTO_TEST_CASE( faulty_address_are_detected )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     {
         k::endpoint const endpoint{ "error"
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE( faulty_address_are_detected )
 
 BOOST_AUTO_TEST_CASE( dns_can_be_resolved )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint const endpoint{ "localhost"
                               , "27980" };
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( dns_can_be_resolved )
 
 BOOST_AUTO_TEST_CASE( ipv4_address_can_be_resolved )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint const endpoint{ "127.0.0.1"
                               , "27980" };
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE( ipv4_address_can_be_resolved )
 
 BOOST_AUTO_TEST_CASE( ipv6_address_can_be_resolved )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint const endpoint{ "::1"
                               , "27980" };
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( ipv6_address_can_be_resolved )
 
 BOOST_AUTO_TEST_CASE( ipv4_socket_can_be_created )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint const endpoint( "127.0.0.1"
                               , k::test::get_temporary_listening_port() );
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( ipv4_socket_can_be_created )
 
 BOOST_AUTO_TEST_CASE( ipv6_socket_can_be_created )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
 
     k::endpoint const endpoint( "::1"
                               , k::test::get_temporary_listening_port() );

--- a/test/unit_tests/test_network.cpp
+++ b/test/unit_tests/test_network.cpp
@@ -56,7 +56,7 @@ struct fixture
         , kd::buffer::const_iterator )
     { };
 
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     k::endpoint ipv4_;
     k::endpoint ipv6_;
 };

--- a/test/unit_tests/test_response_router.cpp
+++ b/test/unit_tests/test_response_router.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_SUITE( test_construction )
 
 BOOST_AUTO_TEST_CASE( can_be_constructed_using_a_reactor )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
     BOOST_REQUIRE_NO_THROW( kd::response_router{ io_service } );
 }
 
@@ -55,7 +55,7 @@ struct fixture
         , error_count_{}
     { }
 
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     kd::response_router router_;
     std::size_t messages_received_count_;
     std::size_t error_count_;

--- a/test/unit_tests/test_response_router.cpp
+++ b/test/unit_tests/test_response_router.cpp
@@ -25,7 +25,7 @@
 
 #include "common.hpp"
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "response_router.hpp"
 

--- a/test/unit_tests/test_timer.cpp
+++ b/test/unit_tests/test_timer.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_SUITE( test_construction )
 
 BOOST_AUTO_TEST_CASE( can_be_constructed_using_a_reactor )
 {
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_service;
     BOOST_REQUIRE_NO_THROW( kd::timer{ io_service } );
 }
 
@@ -58,8 +58,8 @@ struct fixture
         , timeouts_received_{}
     { }
 
-    boost::asio::io_service io_service_;
-    boost::asio::io_service::work work_;
+    boost::asio::io_context io_service_;
+    boost::asio::io_context::work work_;
     kd::timer manager_;
     std::size_t timeouts_received_;
 };

--- a/test/unit_tests/test_timer.cpp
+++ b/test/unit_tests/test_timer.cpp
@@ -53,13 +53,13 @@ struct fixture
 {
     fixture()
         : io_service_{}
-        , work_{ io_service_ }
+        , work_(boost::asio::make_work_guard(io_service_))
         , manager_{ io_service_ }
         , timeouts_received_{}
     { }
 
     boost::asio::io_context io_service_;
-    boost::asio::io_context::work work_;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
     kd::timer manager_;
     std::size_t timeouts_received_;
 };

--- a/test/unit_tests/tracker_mock.hpp
+++ b/test/unit_tests/tracker_mock.hpp
@@ -124,7 +124,7 @@ public:
 
         if ( responses_to_receive_.empty() 
            || responses_to_receive_.front().endpoint != endpoint )
-            io_service_.post( [ on_error ]( void )
+            boost::asio::post( io_service_, [ on_error ]( void )
                     { on_error( detail::make_error_code( UNIMPLEMENTED ) ); } );
         else {
             auto const r = responses_to_receive_.front();
@@ -141,7 +141,7 @@ public:
                                    , r.body.end() );
             };
 
-            io_service_.post( forwarder );
+            boost::asio::post( io_service_, forwarder );
         }
     }
 

--- a/test/unit_tests/tracker_mock.hpp
+++ b/test/unit_tests/tracker_mock.hpp
@@ -28,7 +28,7 @@
 
 #include <queue>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <kademlia/error.hpp>
 

--- a/test/unit_tests/tracker_mock.hpp
+++ b/test/unit_tests/tracker_mock.hpp
@@ -29,6 +29,7 @@
 #include <queue>
 
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
 
 #include <kademlia/error.hpp>
 

--- a/test/unit_tests/tracker_mock.hpp
+++ b/test/unit_tests/tracker_mock.hpp
@@ -49,7 +49,7 @@ public:
      *
      */
     tracker_mock
-        ( boost::asio::io_service & io_service )
+        ( boost::asio::io_context & io_service )
             : io_service_( io_service )
             , id_()
             , message_serializer_( id_ )
@@ -202,7 +202,7 @@ private:
 
 private:
     ///
-    boost::asio::io_service & io_service_;
+    boost::asio::io_context & io_service_;
     ///
     detail::id id_;
     ///


### PR DESCRIPTION
kademlia 4ccfd508f1b50734ff9f4c1db3c5b3bb48bdb404 fails to build with boost 1.87

```
nix-shell -p git cmake boost187
git clone https://github.com/DavidKeller/kademlia
cd kademlia
git checkout 4ccfd508f1b50734ff9f4c1db3c5b3bb48bdb404
mkdir build
cd build
BUILD_TESTING=1 cmake .. && LANG=C make
```

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/first_session.cpp:28:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/session_impl.hpp:37:10: fatal error: boost/asio/io_service.hpp: No such file or directory
   37 | #include <boost/asio/io_service.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### quickfix

use boost 1.86

### similar issues

similar issue: https://github.com/rstudio/rstudio/issues/15688#issuecomment-2649062076

> The build logs also have:
> 
> ```
> /build/rstudio-desktop/src/rstudio-2024.12.0-467/src/cpp/core/include/core/http/AsyncClient.hpp:24:10: fatal error: boost/asio/io_service.hpp: No such file or directory
>    24 | #include <boost/asio/io_service.hpp>
>       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
> compilation terminated.
> ```
> 
> Is Boost.Asio missing from your Boost installation for some reason?



> It looks like it was removed, alongside a lot of other deprecated classes. [chriskohlhoff/asio@49fcd03](https://github.com/chriskohlhoff/asio/commit/49fcd03434e8d43271522fe8d360558b5974ce83)
> 
> Unfortunately, it will probably take some time for us to accommodate these changes.

similar issue: https://github.com/The-OpenROAD-Project/OpenROAD/issues/6373

similar issue: https://github.com/monero-project/monero/issues/9596

### actual fix

trying to fix kademlia ...

documenting this here
because i found no guide for porting from boost 1.86 to boost 1.87

> `sed -i 's/boost::asio::ip::address::from_string/boost::asio::ip::make_address/g' src/kademlia/ip_endpoint.hpp test/unit_tests/*.?pp`

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/first_session.cpp:28:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/session_impl.hpp:37:10: fatal error: boost/asio/io_service.hpp: No such file or directory
   37 | #include <boost/asio/io_service.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```


https://github.com/rstudio/rstudio/pull/15739

```diff
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
```

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/session_impl.hpp:40,
                 from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/first_session.cpp:28:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/message_socket.hpp:72:24: error: 'boost::asio::io_service' has not been declared
   72 |         ( boost::asio::io_service & io_service
      |                        ^~~~~~~~~~
```

```diff
-boost::asio::io_service
+boost::asio::io_context
```

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/first_session.cpp:28:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/session_impl.hpp: In member function 'void kademlia::detail::session_impl::abort()':
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/session_impl.hpp:154:21: error: 'class boost::asio::io_context' has no member named 'post'
  154 |         io_service_.post( service_stopper );
      |                     ^~~~
```

```diff
-        io_service_.post( perform_read );
+        boost::asio::post( io_service_, perform_read );
```

```
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/src/kademlia/message_socket.hpp:346:58: error: no type named 'query' in 'boost::asio::ip::udp::resolver' {aka 'class boost::asio::ip::basic_resolver<boost::asio::ip::udp>'}
  346 |     typename protocol_type::resolver::query::flags const f{};
      |                                                          ^
```

https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/reference/ip__basic_resolver/resolve.html

https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/reference/ip__address_v4/make_address_v4/overload3.html

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/test_fake_socket.cpp:33:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/fake_socket.hpp: In member function 'void kademlia::test::fake_socket::log_packet(const boost::asio::const_buffer&, const endpoint_type&)':
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/fake_socket.hpp:418:31: error: 'buffer_cast' is not a member of 'boost::asio'; did you mean 'buffer_copy'?
  418 |         auto i = boost::asio::buffer_cast< uint8_t const * >( buffer );
      |                               ^~~~~~~~~~~
      |                               buffer_copy
```

```diff
-        auto i = boost::asio::buffer_cast< uint8_t const * >( buffer );
+        auto i = static_cast< uint8_t const * >( buffer.data() );
```

```
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/test_fake_socket.cpp: In member function 'void {anonymous}::fake_socket::test_construction::can_send_and_receive_messages::test_method()':
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/test_fake_socket.cpp:104:20: error: 'work' is not a member of 'boost::asio::io_context'
  104 |     a::io_context::work work(io_service);
      |                    ^~~~
```

fix: remove `boost::asio::io_service::work`

```
In file included from /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/test_store_value_task.cpp:27:
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/tracker_mock.hpp: In member function 'void kademlia::test::tracker_mock::send_request(const RequestType&, const EndpointType&, const TimeoutType&, const OnMessageReceiveCallback&, const OnErrorCallback&)':
/home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/test/unit_tests/tracker_mock.hpp:127:26: error: 'post' is not a member of 'boost::asio'
  127 |             boost::asio::post( io_service_, [ on_error ]( void )
      |                          ^~~~
```

```diff
+#include <boost/asio/post.hpp>
```


### test

```
$ ctest
Test project /home/user/src/libtorrent/libtorrent-issue7926-2/kademlia/build
      Start  1: unit_tests_helpers
 1/26 Test  #1: unit_tests_helpers ...............***Failed    0.08 sec
      Start  2: test_id
 2/26 Test  #2: test_id ..........................   Passed    0.08 sec
      Start  3: test_endpoint
 3/26 Test  #3: test_endpoint ....................   Passed    0.05 sec
      Start  4: test_boost_to_std_error
 4/26 Test  #4: test_boost_to_std_error ..........   Passed    0.02 sec
      Start  5: test_message
 5/26 Test  #5: test_message .....................   Passed    0.06 sec
      Start  6: test_message_serializer
 6/26 Test  #6: test_message_serializer ..........   Passed    0.06 sec
      Start  7: test_lookup_task
 7/26 Test  #7: test_lookup_task .................   Passed    0.01 sec
      Start  8: test_store_value_task
 8/26 Test  #8: test_store_value_task ............   Passed    0.01 sec
      Start  9: test_find_value_task
 9/26 Test  #9: test_find_value_task .............   Passed    0.02 sec
      Start 10: test_ip_endpoint
10/26 Test #10: test_ip_endpoint .................   Passed    0.01 sec
      Start 11: test_peer
11/26 Test #11: test_peer ........................   Passed    0.01 sec
      Start 12: test_error
12/26 Test #12: test_error .......................   Passed    0.01 sec
      Start 13: test_discover_neighbors_task
13/26 Test #13: test_discover_neighbors_task .....   Passed    0.01 sec
      Start 14: test_notify_peer_task
14/26 Test #14: test_notify_peer_task ............   Passed    0.01 sec
      Start 15: test_response_router
15/26 Test #15: test_response_router .............   Passed    0.01 sec
      Start 16: test_response_callbacks
16/26 Test #16: test_response_callbacks ..........   Passed    0.01 sec
      Start 17: test_timer
17/26 Test #17: test_timer .......................***Failed    0.01 sec
      Start 18: test_network
18/26 Test #18: test_network .....................   Passed    0.01 sec
      Start 19: test_message_socket
19/26 Test #19: test_message_socket ..............   Passed    5.08 sec
      Start 20: test_log
20/26 Test #20: test_log .........................   Passed    0.01 sec
      Start 21: test_r
21/26 Test #21: test_r ...........................   Passed    0.01 sec
      Start 22: test_routing_table
22/26 Test #22: test_routing_table ...............   Passed    0.01 sec
      Start 23: test_session
23/26 Test #23: test_session .....................   Passed    0.22 sec
      Start 24: test_first_session
24/26 Test #24: test_first_session ...............   Passed    0.02 sec
      Start 25: test_concurrent_guard
25/26 Test #25: test_concurrent_guard ............   Passed    0.01 sec
      Start 26: test_engine
```

### fixme

fixme: `test_engine` hangs with 100% cpu load

```
$ ./test/unit_tests/test_engine
Running 3 test cases...
```
